### PR TITLE
Rendering whole data with reasonable LOD

### DIFF
--- a/Assets/Resources/20x20.txt.meta
+++ b/Assets/Resources/20x20.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f51584ab5c697a1428537e02043cbb74
+timeCreated: 1518442058
+licenseType: Free
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map Data/DisplayReadySlice.cs
+++ b/Assets/Scripts/Map Data/DisplayReadySlice.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+public class DisplayReadySlice : MapDataSlice {
+
+	public int lod;
+	public DisplayReadySlice(MapDataSlice slice, int lod) : base(slice) {
+		this.lod = lod;
+	}
+
+	private int GetActualLOD() {
+		return lod == 0 ? 1 : lod * 2;
+	}
+
+	public override int GetWidth() {
+
+        int trueValue = base.GetWidth();
+        int remain = trueValue % GetActualLOD();
+        return trueValue - remain + (this.lod > 0 ? 1 : 0);
+
+    }
+
+    public override int GetHeight() {
+
+        int trueValue = base.GetHeight();
+        int remain = trueValue % GetActualLOD();
+        return trueValue - remain + (this.lod > 0 ? 1 : 0);
+
+    }
+	
+}

--- a/Assets/Scripts/Map Data/DisplayReadySlice.cs
+++ b/Assets/Scripts/Map Data/DisplayReadySlice.cs
@@ -1,6 +1,10 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 
+/// <summary>
+/// A MapDataSlice with LOD-related functionality included
+/// </summary>
+
 public class DisplayReadySlice : MapDataSlice {
 
 	public int lod;

--- a/Assets/Scripts/Map Data/DisplayReadySlice.cs.meta
+++ b/Assets/Scripts/Map Data/DisplayReadySlice.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 4dce8bdae539c144facde5d924653cb1
+timeCreated: 1518599300
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map Data/MapData.cs
+++ b/Assets/Scripts/Map Data/MapData.cs
@@ -69,6 +69,9 @@ public class MapData {
     }
 
     public List<MapDataSlice> GetSlices(int topLeftX, int topLeftY, int bottomRightX, int bottomRightY, int sliceWidth, int sliceHeight, bool doOffset = true) {
+        if(sliceHeight <= (doOffset ? 1 : 0) || sliceWidth <= (doOffset ? 1 : 0)) {
+            throw new System.ArgumentException("Too small slice width (" + sliceWidth + ") or height (" + sliceHeight + ")");
+        }
         List<MapDataSlice> slices = new List<MapDataSlice>();
         for(int y = topLeftY; y < bottomRightY; y += sliceHeight - (doOffset ? 1 : 0)) {
             for(int x = topLeftX; x < bottomRightX; x += sliceWidth - (doOffset ? 1: 0)) {

--- a/Assets/Scripts/Map Data/MapData.cs
+++ b/Assets/Scripts/Map Data/MapData.cs
@@ -20,7 +20,7 @@ public class MapData {
 
     public MapData(float[,] data, MapMetadata metadata) {
         this.data = data;
-        scale = 1 / (float)Mathf.Max(data.GetLength(0), data.GetLength(1));
+        scale = 1;/// (float)Mathf.Max(data.GetLength(0), data.GetLength(1));
         this.metadata = metadata;
     }
 
@@ -68,14 +68,13 @@ public class MapData {
         return (GetRaw(x, y) - metadata.minheight) / (metadata.maxheight - metadata.minheight);
     }
 
-    public List<MapData> GetSlices(int sliceSize) {
+    public List<MapData> GetSlices(int sliceSize, int LOD) {
         List<MapData> slices = new List<MapData>();
         for(int y = 0; y < GetHeight(); y += sliceSize - 1) {
             for(int x = 0; x < GetWidth(); x += sliceSize - 1) {
-                slices.Add(new MapDataSlice(this, x, y, sliceSize, sliceSize));
+                slices.Add(new MapDataSlice(this, x, y, sliceSize, sliceSize, LOD));
             }
         }
         return slices;
     }
-
 }

--- a/Assets/Scripts/Map Data/MapData.cs
+++ b/Assets/Scripts/Map Data/MapData.cs
@@ -20,7 +20,7 @@ public class MapData {
 
     public MapData(float[,] data, MapMetadata metadata) {
         this.data = data;
-        scale = 1;/// (float)Mathf.Max(data.GetLength(0), data.GetLength(1));
+        scale = 1 / (float)Mathf.Max(data.GetLength(0), data.GetLength(1));
         this.metadata = metadata;
     }
 

--- a/Assets/Scripts/Map Data/MapDataSlice.cs
+++ b/Assets/Scripts/Map Data/MapDataSlice.cs
@@ -7,18 +7,36 @@ using UnityEngine;
 
 public class MapDataSlice : MapData {
 
-    private int topLeftX, topLeftY, width, height;
+    private int topLeftX, topLeftY, width, height, LOD;
 
-    public MapDataSlice(MapData mapData, int topLeftX, int topLeftY, int width, int height) : base(mapData){
+    public MapDataSlice(MapData mapData, int topLeftX, int topLeftY, int width, int height, int LOD) : base(mapData){
         this.topLeftX = topLeftX; this.topLeftY = topLeftY;
         this.width = width; this.height = height;
+        this.LOD = LOD;
     }
 
     public override int GetWidth() {
-        return topLeftX + width > base.GetWidth() ? base.GetWidth() - topLeftX : width;
+
+        if (topLeftX + width <= base.GetWidth()) return width;
+
+        int trueValue = base.GetWidth() - topLeftX;
+        int lod = LOD == 0 ? 1 : LOD * 2;
+        int remain = trueValue % lod;
+        return (remain == 0 ? trueValue : trueValue - remain) + 1;
+
+        //return topLeftX + width > base.GetWidth() ? base.GetWidth() - topLeftX : width;
     }
+
     public override int GetHeight() {
-        return topLeftY + height > base.GetHeight() ? base.GetHeight() - topLeftY : height;
+
+        if (topLeftY + height <= base.GetHeight()) return height;
+
+        int trueValue = base.GetHeight() - topLeftY;
+        int lod = LOD == 0 ? 1 : LOD * 2;
+        int remain = trueValue % lod;
+        return (remain == 0 ? trueValue : trueValue - remain) + 1;
+
+        //return topLeftY + height > base.GetHeight() ? base.GetHeight() - topLeftY : height;
     }
 
     public override Vector2 GetTopLeft(){

--- a/Assets/Scripts/Map Data/MapDataSlice.cs
+++ b/Assets/Scripts/Map Data/MapDataSlice.cs
@@ -7,36 +7,38 @@ using UnityEngine;
 
 public class MapDataSlice : MapData {
 
-    private int topLeftX, topLeftY, width, height, LOD;
+    protected int topLeftX, topLeftY, width, height;
 
-    public MapDataSlice(MapData mapData, int topLeftX, int topLeftY, int width, int height, int LOD) : base(mapData){
+    public MapDataSlice(MapData mapData, int topLeftX, int topLeftY, int width, int height) : base(mapData){
         this.topLeftX = topLeftX; this.topLeftY = topLeftY;
         this.width = width; this.height = height;
-        this.LOD = LOD;
+    }
+
+    public MapDataSlice(MapDataSlice slice) : this(slice, slice.topLeftX, slice.topLeftY, slice.width, slice.height) {
+    }
+
+    public int GetX() {
+        return topLeftX;
+    }
+
+    public int GetY() {
+        return topLeftY;
+    }
+
+    public void SetX(int x) {
+        topLeftX = x;
+    }
+
+    public void SetY(int y) {
+        topLeftY = y;
     }
 
     public override int GetWidth() {
-
-        if (topLeftX + width <= base.GetWidth()) return width;
-
-        int trueValue = base.GetWidth() - topLeftX;
-        int lod = LOD == 0 ? 1 : LOD * 2;
-        int remain = trueValue % lod;
-        return (remain == 0 ? trueValue : trueValue - remain) + 1;
-
-        //return topLeftX + width > base.GetWidth() ? base.GetWidth() - topLeftX : width;
+        return topLeftX + width > base.GetWidth() ? base.GetWidth() - topLeftX : width;
     }
 
     public override int GetHeight() {
-
-        if (topLeftY + height <= base.GetHeight()) return height;
-
-        int trueValue = base.GetHeight() - topLeftY;
-        int lod = LOD == 0 ? 1 : LOD * 2;
-        int remain = trueValue % lod;
-        return (remain == 0 ? trueValue : trueValue - remain) + 1;
-
-        //return topLeftY + height > base.GetHeight() ? base.GetHeight() - topLeftY : height;
+        return topLeftY + height > base.GetHeight() ? base.GetHeight() - topLeftY : height;
     }
 
     public override Vector2 GetTopLeft(){

--- a/Assets/Scripts/Map Visuals/MapDisplay.cs
+++ b/Assets/Scripts/Map Visuals/MapDisplay.cs
@@ -9,10 +9,9 @@ using System.Collections;
 public class MapDisplay : MonoBehaviour {
 
 	public GameObject visualMap;
-	public Renderer textureRender;
-	public MeshFilter meshFilter;
-	public MeshRenderer meshRenderer;
-	public GameObject visual;
+	private Renderer textureRender;
+	private MeshFilter meshFilter;
+	private MeshRenderer meshRenderer;
 
 	public GameObject CreateVisual(GameObject visual) {
 		visualMap     = Instantiate(visual) as GameObject;

--- a/Assets/Scripts/Map Visuals/MapGenerator.cs
+++ b/Assets/Scripts/Map Visuals/MapGenerator.cs
@@ -13,8 +13,8 @@ public class MapGenerator : MonoBehaviour {
 	public enum DrawMode {NoiseMap, ColourMap, Mesh};
 	public DrawMode drawMode;
 
-    public const int mapChunkSize = 255;
-    [Range(0, 6)]
+    public const int mapChunkSize = 241;
+    [Range(0, 24)]
     public int levelOfDetail;
     public float meshHeightMultiplier;
 
@@ -26,13 +26,14 @@ public class MapGenerator : MonoBehaviour {
 
 	private MapData mapData;
 	private MapMetadata mapMetadata;
-	private const string mapDataPath = "Assets/Resources/grandcanyon.txt";
+    //private const string mapDataPath = "Assets/Resources/20x20.txt";
+    private const string mapDataPath = "Assets/Resources/grandcanyon.txt";
 
     public void Start()
     {
         SmoothRegions(regionsSmoothCount);
 		mapMetadata = MapDataImporter.ReadMetadata(mapDataPath);
-		mapData     = MapDataImporter.ReadMapData(mapDataPath, mapMetadata);
+        mapData     = MapDataImporter.ReadMapData(mapDataPath, mapMetadata);
         GenerateMap();
     }
 
@@ -81,7 +82,7 @@ public class MapGenerator : MonoBehaviour {
         // GenerateNoiseMap returns noise, if need it create a new MapData with fake MapMetaData
 		//float[,] noiseMap = Noise.GenerateNoiseMap (mapChunkSize, mapChunkSize, seed, noiseScale, octaves, persistance, lacunarity, offset);
 
-		foreach(MapData slice in (drawMode == DrawMode.Mesh ? mapData : new NoiseMapData(mapChunkSize)).GetSlices(121)) {
+		foreach(MapData slice in (drawMode == DrawMode.Mesh ? mapData : new NoiseMapData(mapChunkSize)).GetSlices(241, levelOfDetail)) {
 			int width  = slice.GetWidth();
 			int height = slice.GetHeight();
 

--- a/Assets/Scripts/Map Visuals/MapGenerator.cs
+++ b/Assets/Scripts/Map Visuals/MapGenerator.cs
@@ -26,8 +26,8 @@ public class MapGenerator : MonoBehaviour {
 
 	private MapData mapData;
 	private MapMetadata mapMetadata;
-    //private const string mapDataPath = "Assets/Resources/20x20.txt";
-    private const string mapDataPath = "Assets/Resources/grandcanyon.txt";
+    private const string mapDataPath = "Assets/Resources/20x20.txt";
+    //private const string mapDataPath = "Assets/Resources/grandcanyon.txt";
 
     public void Start()
     {
@@ -81,20 +81,20 @@ public class MapGenerator : MonoBehaviour {
 
         // GenerateNoiseMap returns noise, if need it create a new MapData with fake MapMetaData
 		//float[,] noiseMap = Noise.GenerateNoiseMap (mapChunkSize, mapChunkSize, seed, noiseScale, octaves, persistance, lacunarity, offset);
-		int[,] lodMatrix = new int[7, 7] {
-			{3, 3, 3, 3, 3, 3, 3,},
-			{3, 2, 2, 2, 2, 2, 3,},
-			{3, 2, 1, 1, 1, 2, 3,},
-			{3, 2, 1, 0, 1, 2, 3,},
-			{3, 2, 1, 1, 1, 2, 3,},
-			{3, 2, 2, 2, 2, 2, 3,},
-			{3, 3, 3, 3, 3, 3, 3,},
+		int[,] lodMatrix = new int[7, 7] { // Is there some cleaner way to do this >:
+			{levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail,},
+			{levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail,},
+			{levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail,},
+			{levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail,},
+			{levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail,},
+			{levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail,},
+			{levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail, levelOfDetail,},
 		};
 
 		MapData actualMapData = drawMode == DrawMode.Mesh ? mapData : new NoiseMapData(mapChunkSize);
 
 		foreach(DisplayReadySlice slice in actualMapData.GetDisplayReadySlices(
-			actualMapData.GetWidth(), actualMapData.GetHeight(), 10, 10, lodMatrix)) {
+			actualMapData.GetWidth(), actualMapData.GetHeight(), 0, 0, lodMatrix)) {
 			int width  = slice.GetWidth();
 			int height = slice.GetHeight();
 

--- a/Assets/Scripts/Map Visuals/MapGenerator.cs
+++ b/Assets/Scripts/Map Visuals/MapGenerator.cs
@@ -81,8 +81,20 @@ public class MapGenerator : MonoBehaviour {
 
         // GenerateNoiseMap returns noise, if need it create a new MapData with fake MapMetaData
 		//float[,] noiseMap = Noise.GenerateNoiseMap (mapChunkSize, mapChunkSize, seed, noiseScale, octaves, persistance, lacunarity, offset);
+		int[,] lodMatrix = new int[7, 7] {
+			{3, 3, 3, 3, 3, 3, 3,},
+			{3, 2, 2, 2, 2, 2, 3,},
+			{3, 2, 1, 1, 1, 2, 3,},
+			{3, 2, 1, 0, 1, 2, 3,},
+			{3, 2, 1, 1, 1, 2, 3,},
+			{3, 2, 2, 2, 2, 2, 3,},
+			{3, 3, 3, 3, 3, 3, 3,},
+		};
 
-		foreach(MapData slice in (drawMode == DrawMode.Mesh ? mapData : new NoiseMapData(mapChunkSize)).GetSlices(241, levelOfDetail)) {
+		MapData actualMapData = drawMode == DrawMode.Mesh ? mapData : new NoiseMapData(mapChunkSize);
+
+		foreach(DisplayReadySlice slice in actualMapData.GetDisplayReadySlices(
+			actualMapData.GetWidth(), actualMapData.GetHeight(), 10, 10, lodMatrix)) {
 			int width  = slice.GetWidth();
 			int height = slice.GetHeight();
 
@@ -92,11 +104,11 @@ public class MapGenerator : MonoBehaviour {
 			GameObject visualObject = display.CreateVisual(visual);
             visualObject.transform.parent = this.transform;
 			if (drawMode == DrawMode.NoiseMap) {
-				display.DrawMesh (MeshGenerator.GenerateTerrainMesh (slice, meshHeightMultiplier, levelOfDetail), TextureGenerator.TextureFromHeightMap (slice), slice.GetScale());
+				display.DrawMesh (MeshGenerator.GenerateTerrainMesh (slice, meshHeightMultiplier, slice.lod), TextureGenerator.TextureFromHeightMap (slice), slice.GetScale());
 			} else if (drawMode == DrawMode.ColourMap) {
-				display.DrawMesh (MeshGenerator.GenerateTerrainMesh (slice, meshHeightMultiplier, levelOfDetail), TextureGenerator.TextureFromColourMap (colourMap, width, height), slice.GetScale());
+				display.DrawMesh (MeshGenerator.GenerateTerrainMesh (slice, meshHeightMultiplier, slice.lod), TextureGenerator.TextureFromColourMap (colourMap, width, height), slice.GetScale());
 			} else if (drawMode == DrawMode.Mesh) {
-				display.DrawMesh (MeshGenerator.GenerateTerrainMesh (slice, meshHeightMultiplier, levelOfDetail), TextureGenerator.TextureFromColourMap (colourMap, width, height), slice.GetScale());
+				display.DrawMesh (MeshGenerator.GenerateTerrainMesh (slice, meshHeightMultiplier, slice.lod), TextureGenerator.TextureFromColourMap (colourMap, width, height), slice.GetScale());
 			}
 		}
 	}

--- a/Assets/Scripts/Map Visuals/MeshGenerator.cs
+++ b/Assets/Scripts/Map Visuals/MeshGenerator.cs
@@ -18,8 +18,9 @@ public static class MeshGenerator {
 
         int meshSimplificationIncrement = (levelOfDetail == 0) ? 1 : levelOfDetail * 2;
         int verticesPerLine = (width - 1) / meshSimplificationIncrement + 1;
+        int verticesPerColumn = (height - 1) / meshSimplificationIncrement + 1;
 
-        MeshData meshData = new MeshData (width, height);
+        MeshData meshData = new MeshData (verticesPerLine + 1, verticesPerColumn + 1);
 		int vertexIndex = 0;
 
 		for (int y = 0; y < height; y+= meshSimplificationIncrement) {

--- a/Assets/Scripts/Map Visuals/MeshGenerator.cs
+++ b/Assets/Scripts/Map Visuals/MeshGenerator.cs
@@ -11,6 +11,7 @@ public static class MeshGenerator {
 	public static MeshData GenerateTerrainMesh(MapData mapData, float heightMultiplier, int levelOfDetail, float minHeight = 0f) {
 		int width       = mapData.GetWidth();
 		int height      = mapData.GetHeight();
+        //Debug.Log("w: " + width + "  h:" + height);
 		Vector2 topLeft = mapData.GetTopLeft();
 		float topLeftX  = topLeft.x;
 		float topLeftZ  = topLeft.y;

--- a/Assets/Tests/Editor/Map Data/DisplayReadySliceTest.cs
+++ b/Assets/Tests/Editor/Map Data/DisplayReadySliceTest.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+
+public class DisplayReadySliceTest {
+
+    MapData data;
+
+    [SetUp]
+    public void Setup() {
+        data = MapData.ForTesting(new float[5, 5] {
+            {0.0F, 0.1F, 0.2F, 0.3F, 0.4F},
+            {1.0F, 1.1F, 1.2F, 1.3F, 1.4F},
+            {2.0F, 2.1F, 2.2F, 2.3F, 2.4F},
+            {3.0F, 3.1F, 3.2F, 3.3F, 3.4F},
+            {4.0F, 4.1F, 4.2F, 4.3F, 4.4F},
+        });
+    }
+
+    [Test]
+    public void GetWidthCorrect() {
+        DisplayReadySlice slice = new DisplayReadySlice(new MapDataSlice(data, 2, 2, 5, 5), 2);
+        Assert.True(slice.GetWidth() == 1, "DisplayReadySlice width was " + slice.GetWidth() + ", should have been 1");
+    }
+
+    [Test]
+    public void GetHeightCorrect() {
+        DisplayReadySlice slice = new DisplayReadySlice(new MapDataSlice(data, 3, 0, 5, 5), 2);
+        Assert.True(slice.GetHeight() == 5, "DisplayReadySlice width was " + slice.GetHeight() + ", should have been 5");
+    }
+
+}

--- a/Assets/Tests/Editor/Map Data/DisplayReadySliceTest.cs.meta
+++ b/Assets/Tests/Editor/Map Data/DisplayReadySliceTest.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: e8bcd333487e79c46a10bc227c6806f5
+timeCreated: 1518613343
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/Map Data/MapDataTest.cs
+++ b/Assets/Tests/Editor/Map Data/MapDataTest.cs
@@ -100,4 +100,28 @@ public class MapDataTest {
         float altitude = slice.GetRaw(1,1);
         Assert.True(altitude == 5F, "Slice GetRaw(1,1) returns incorrect value.");
     }
+
+    [Test]
+    public void GetSlices_WithOffsetCorrect() {
+        List<MapDataSlice> slices = mapdata.GetSlices(1, 2, 2, 3, 2, 2);
+        Assert.True(Mathf.Approximately(6.0F, slices[0].GetRaw(0, 0)), 
+            "Slice with offset 0 GetRaw(0, 0) == " + slices[0].GetRaw(0, 0) + "; should be 6.0");
+    }
+
+    [Test]
+    public void GetDisplayReadySlices_CountAndLODsCorrect() {
+        // Other display ready slicing functionality will be tested in further tasks when it will actually be used
+        int[,] lodMatrix = new int[2,2] {
+            {1,2}, {3,4}
+        };
+        List<DisplayReadySlice> slices = mapdata.GetDisplayReadySlices(2, 3, 0, 0, lodMatrix);
+        Assert.True(slices.Count == 4, "Incorrect number of slices after GetDisplayReadySlices (was " + slices.Count + ", should be 4)");
+        for(int y = 0; y < lodMatrix.GetLength(1); y++) {
+            for(int x = 0; x < lodMatrix.GetLength(0); x++) {
+                Assert.True(lodMatrix[x, y] == slices[y * lodMatrix.GetLength(0) + x].lod, "LOD was incorrect for piece at " + x + ", " + y 
+                + " (was " + slices[y * lodMatrix.GetLength(0) + x].lod + ", should be " + lodMatrix[x, y] + ")");
+            }
+        }
+    }
+
 }

--- a/Assets/Tests/Editor/Map Data/MapDataTest.cs
+++ b/Assets/Tests/Editor/Map Data/MapDataTest.cs
@@ -70,7 +70,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_SliceHeightCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2, 0);
+        List<MapData> slices = mapdata.GetSlices(2);
         MapData slice = slices.ElementAt(0);
         int sliceHeight = slice.GetHeight();
         Assert.True(sliceHeight == 2, "Slice GetHeight() returns incorrect value.");
@@ -78,7 +78,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_SliceWidthCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2, 0);
+        List<MapData> slices = mapdata.GetSlices(2);
         MapData slice = slices.ElementAt(0);
         int sliceWidth = slice.GetWidth();
         Assert.True(sliceWidth == 2, "Slice GetWidth() returns incorrect value.");
@@ -86,7 +86,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_GetTopLeftCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2, 0);
+        List<MapData> slices = mapdata.GetSlices(2);
         MapData slice = slices.ElementAt(2);
         Vector2 sliceTopLeft = slice.GetTopLeft();
         Assert.True(Mathf.Approximately(sliceTopLeft.x, -0.5F), "Slice GetTopLeft() returns incorrect x value:" + sliceTopLeft.x);
@@ -95,7 +95,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_GetRawCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2, 0);
+        List<MapData> slices = mapdata.GetSlices(2);
         MapData slice = slices.ElementAt(0);
         float altitude = slice.GetRaw(1,1);
         Assert.True(altitude == 5F, "Slice GetRaw(1,1) returns incorrect value.");

--- a/Assets/Tests/Editor/Map Data/MapDataTest.cs
+++ b/Assets/Tests/Editor/Map Data/MapDataTest.cs
@@ -70,7 +70,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_SliceHeightCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2);
+        List<MapData> slices = mapdata.GetSlices(2, 0);
         MapData slice = slices.ElementAt(0);
         int sliceHeight = slice.GetHeight();
         Assert.True(sliceHeight == 2, "Slice GetHeight() returns incorrect value.");
@@ -78,7 +78,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_SliceWidthCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2);
+        List<MapData> slices = mapdata.GetSlices(2, 0);
         MapData slice = slices.ElementAt(0);
         int sliceWidth = slice.GetWidth();
         Assert.True(sliceWidth == 2, "Slice GetWidth() returns incorrect value.");
@@ -86,7 +86,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_GetTopLeftCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2);
+        List<MapData> slices = mapdata.GetSlices(2, 0);
         MapData slice = slices.ElementAt(2);
         Vector2 sliceTopLeft = slice.GetTopLeft();
         Assert.True(Mathf.Approximately(sliceTopLeft.x, -0.5F), "Slice GetTopLeft() returns incorrect x value:" + sliceTopLeft.x);
@@ -95,7 +95,7 @@ public class MapDataTest {
 
     [Test]
     public void GetSlices_GetRawCorrect() {
-        List<MapData> slices = mapdata.GetSlices(2);
+        List<MapData> slices = mapdata.GetSlices(2, 0);
         MapData slice = slices.ElementAt(0);
         float altitude = slice.GetRaw(1,1);
         Assert.True(altitude == 5F, "Slice GetRaw(1,1) returns incorrect value.");

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.3.0f3
+m_EditorVersion: 2017.1.0f3


### PR DESCRIPTION
A "Reasonable level of detail" for 20x20km data is 6 (results in ~150k tris)
DisplayReadySlice has some extra functionality (namely, support for slicing to multiple LODs viea lodMatrix) that is currently not being used and therefore is poorly tested - don't be too rough with that 😄 
Tests successful in staging: https://developer.cloud.unity3d.com/build/orgs/jiilaitala/projects/3dmaps/buildtargets/staging-android/builds/13/log