### PR TITLE
Refactored TextureGenerator to handle different resolutions

### DIFF
--- a/Assets/Scripts/Map Visuals/MapDisplayData.cs
+++ b/Assets/Scripts/Map Visuals/MapDisplayData.cs
@@ -41,16 +41,6 @@ public class MapDisplayData {
 		mapData.lod     = originalLod;
 	}
 
-    public Color[] CalculateColourMap(MapData mapData, int lod) {
-		if(SatelliteImageService.UseSatelliteImage()) {
-            textureLod = 0;
-            return TextureGenerator.ColorMapForSatelliteImage(mapData);
-        } else {
-            textureLod = lod;
-            return TextureGenerator.ColorMapForHeightAndAreas(mapData, lod);
-        }
-	}
-
 	public void SetStatus(MapDisplayStatus newStatus) {
 		this.status = newStatus;
 	}
@@ -142,7 +132,13 @@ public class MapDisplayData {
     }
 
     public Texture2D GenerateTexture(int lod) {
-        return TextureGenerator.TextureFromColourMap(CalculateColourMap(mapData, lod), mapData.GetWidth(), mapData.GetHeight());
+		if (SatelliteImageService.UseSatelliteImage ()) {
+			textureLod = 0;
+		} else {
+			textureLod = lod;
+		}
+		
+		return TextureGenerator.GenerateTexture (mapData, lod);
 	}
 
 	public void UpdateLOD(int lod) {

--- a/Assets/Tests/Editor/Map Visuals/MapDisplayDataTest.cs
+++ b/Assets/Tests/Editor/Map Visuals/MapDisplayDataTest.cs
@@ -109,9 +109,10 @@ public class MapDisplayDataTest {
         SatelliteImageService.satelliteImage = image;
         SatelliteImageService.useSatelliteImage = true;
 
-		Color[] colorMap = dispData.CalculateColourMap(data, 0);
-		Assert.True (colorMap [0] == Color.red);
-		Assert.True (colorMap [99] == Color.blue);
+		Texture2D textureSlice = dispData.GenerateTexture(0);
+
+		Assert.True(textureSlice.GetPixel(0, 0) == Color.red);
+		Assert.True(textureSlice.GetPixel(9, 9) == Color.blue);
 	}
 
 
@@ -136,8 +137,13 @@ public class MapDisplayDataTest {
         SatelliteImageService.satelliteImage = image;
         SatelliteImageService.useSatelliteImage = true;
 
-		Color[] colorMap = dispData.CalculateColourMap (data, 0);
-		Assert.True (colorMap [0] == Color.red);
-		Assert.True (colorMap [99] == Color.blue);
+		//Color[] colorMap = dispData.GenerateTexture();
+		Texture2D textureSlice = dispData.GenerateTexture(0);
+
+		Assert.True(textureSlice.GetPixel(0, 0) == Color.red);
+		Assert.True(textureSlice.GetPixel(9, 9) == Color.blue);
+
+		//Assert.True (colorMap [0] == Color.red);
+		//Assert.True (colorMap [99] == Color.blue);
 	}
 }


### PR DESCRIPTION
Fixed texture generation missing the correct widths and heights of color maps when texture resolution differs from 1 pixel per height map point.