### PR TITLE
Fixes to trail labels

### DIFF
--- a/Assets/Scripts/OSM Visuals/ObjectRotator.cs
+++ b/Assets/Scripts/OSM Visuals/ObjectRotator.cs
@@ -9,6 +9,25 @@ using UnityEngine;
 public class ObjectRotator : MonoBehaviour {
 
 	void Update () {
-		transform.LookAt (2 * transform.position - Camera.main.transform.position, Camera.main.transform.rotation * Vector3.up);
+
+		/*Quaternion quaternion = new Quaternion ();
+		quaternion.x = Camera.main.transform.rotation.x;
+		quaternion.y = transform.position.x - transform.localPosition.x;
+
+		transform.rotation = quaternion;*/
+
+		transform.LookAt(transform.position - Camera.main.transform.rotation * Vector3.back,
+		Camera.main.transform.rotation * Vector3.up);
+
+		/*transform.LookAt(transform.position + Camera.main.transform.rotation * Vector3.back,
+			Camera.main.transform.rotation * Vector3.up);*/
+
+		//transform.LookAt (Camera.main.transform.position - transform.position, Camera.main.transform.rotation * Vector3.up);
+
+		/*transform.LookAt(2 * transform.position - Camera.main.transform.position + Camera.main.transform.rotation * Vector3.back,
+			Camera.main.transform.rotation * Vector3.up);*/
+		
+
+		//transform.LookAt (2 * transform.position - Camera.main.transform.position, Camera.main.transform.rotation * new Vector3(0, 1, 0));
 	}
 }

--- a/Assets/Scripts/OSM Visuals/ObjectRotator.cs
+++ b/Assets/Scripts/OSM Visuals/ObjectRotator.cs
@@ -9,25 +9,7 @@ using UnityEngine;
 public class ObjectRotator : MonoBehaviour {
 
 	void Update () {
-
-		/*Quaternion quaternion = new Quaternion ();
-		quaternion.x = Camera.main.transform.rotation.x;
-		quaternion.y = transform.position.x - transform.localPosition.x;
-
-		transform.rotation = quaternion;*/
-
 		transform.LookAt(transform.position - Camera.main.transform.rotation * Vector3.back,
-		Camera.main.transform.rotation * Vector3.up);
-
-		/*transform.LookAt(transform.position + Camera.main.transform.rotation * Vector3.back,
-			Camera.main.transform.rotation * Vector3.up);*/
-
-		//transform.LookAt (Camera.main.transform.position - transform.position, Camera.main.transform.rotation * Vector3.up);
-
-		/*transform.LookAt(2 * transform.position - Camera.main.transform.position + Camera.main.transform.rotation * Vector3.back,
-			Camera.main.transform.rotation * Vector3.up);*/
-		
-
-		//transform.LookAt (2 * transform.position - Camera.main.transform.position, Camera.main.transform.rotation * new Vector3(0, 1, 0));
+			Camera.main.transform.rotation * Vector3.up);
 	}
 }

--- a/Assets/Scripts/OSM Visuals/TrailLabel.cs
+++ b/Assets/Scripts/OSM Visuals/TrailLabel.cs
@@ -4,13 +4,15 @@ using UnityEngine;
 
 /// <summary>
 /// Class for storing information about trail labels. Contains a list of possible label 
-/// positions in Unity's coordinates as well as the label GameObject and name. 
+/// positions in Unity's coordinates as well as the label GameObject and name. LabelState
+/// is used to store information about if and how the label is currently being displayed.
 /// </summary>
 
 public class TrailLabel {
 	public List<Vector3> unityPositions;
 	public GameObject labelObject;
 	public string name;
+	public LabelState state;
 
 	public TrailLabel() {
 		unityPositions = new List<Vector3> ();
@@ -20,5 +22,8 @@ public class TrailLabel {
 		this.unityPositions = unityPositions;
 		this.labelObject = labelObject;
 		this.name = name;
+		this.state = LabelState.outOfSight;
 	}
 }
+
+public enum LabelState {visible, fadingOut, outOfSight, fadingIn};


### PR DESCRIPTION
Corrected the orientation of labels when they turn towards the camera, refactored the label movement methods and added a fade effect to trail labels when they appear and disappear.
Tests passed on staging: https://developer.cloud.unity3d.com/build/orgs/jiilaitala/projects/3dmaps/buildtargets/staging-android/builds/64/log